### PR TITLE
Fix CI Azure Docker cleanup by switching to powershell action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         uses: azure/login@v1.3.0
         with:
           creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
+          enable-AzPSSession: true
       - name: Setup RavenDB
         id: setup-ravendb
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           dotnet test src --configuration Release --no-build --framework net5.0 --logger "GitHubActions;report-warnings=false"
       - name: Teardown RavenDB
         if: ${{ always() }}
-        shell: pwsh
-        run: |
-          $ignore = az container delete --resource-group GitHubActions-RG --name ${{ steps.setup-ravendb.outputs.hostname }} --yes
+        uses: Azure/powershell@v1
+        with:
+          inlineScript: Remove-AzContainerGroup -ResourceGroupName GitHubActions-RG -Name ${{ steps.setup-ravendb.outputs.hostname }}
+          azPSVersion: latest


### PR DESCRIPTION
Version 2.28.0 of the Azure CLI introduces [a bug](https://github.com/Azure/azure-cli/issues/19489) that prevents deletion of containers.

This PR switches to the powershell module to perform the cleanup