### PR TITLE
Add cluster-wide transactions support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,14 +96,8 @@ jobs:
           } While($tcpClient.Connected -ne "True")
           echo "Connection verified"
           
-      - name: Run Windows tests
-        if: runner.os == 'Windows'
-        run: dotnet test src --configuration Release --no-build --logger "GitHubActions;report-warnings=false"
-      - name: Run Linux tests
-        if: runner.os == 'Linux'
-        run: |
-          dotnet test src --configuration Release --no-build --framework netcoreapp3.1 --logger "GitHubActions;report-warnings=false"
-          dotnet test src --configuration Release --no-build --framework net5.0 --logger "GitHubActions;report-warnings=false"
+      - name: Run tests
+        uses: Particular/run-tests-action@v1.0.0
       - name: Teardown RavenDB
         if: ${{ always() }}
         uses: Azure/powershell@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,39 +68,93 @@ jobs:
         id: setup-ravendb
         shell: pwsh
         run: |
-          $hostname = "psw-ravendb-$(Get-Random)"
-          echo "::set-output name=hostname::$hostname"
-          echo "Creating RavenDB container $name (This can take awhile.)"
-          $details = az container create --image ravendb/ravendb:5.2-ubuntu-latest  --name $hostname --dns-name-label $hostname --resource-group GitHubActions-RG --cpu 1 --memory 3.5 --ports 8080 38888 --ip-address public -e RAVEN_ARGS='--ServerUrl=http://0.0.0.0:8080 --Setup.Mode=None --License.Eula.Accepted=true --Security.UnsecuredAccessAllowed=PublicNetwork' | ConvertFrom-Json
+          $hostInfo = curl -H Metadata:true "169.254.169.254/metadata/instance?api-version=2017-08-01" | ConvertFrom-Json
+          $region = $hostInfo.compute.location
+          $license = '${{ secrets.RAVENDB_LICENSE_WINDOWS }}'
+          if ($PSVersionTable.Platform -eq 'Unix') {
+              $license = '${{ secrets.RAVENDB_LICENSE_LINUX }}'
+          }
 
-          $fqdn=$details.ipAddress.fqdn
-          echo "::add-mask::$fqdn"
+          function NewRavenDBNode {
+              param (
+                  $region,
+                  $prefix,
+                  $instanceId,
+                  $runnerOs
+              )
 
-          echo "Tagging container image"
-          $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
-          $ignore = az tag create --resource-id $details.id --tags Package=Gateway.RavenDB RunnerOS=${{ runner.os }} $dateTag
+              $hostname = "$prefix-$instanceId"
 
-          echo "RavenSingleNodeUrl=http://$($fqdn):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          
-          $tcpClient = New-Object Net.Sockets.TcpClient
-          echo "Verifying connection"
-          do
-          {
-              try
+              # echo will mess up the return value
+              Write-Debug "Creating RavenDB container $hostname in $region (This can take a while.)"
+
+              $details = az container create --image ravendb/ravendb:5.2-ubuntu-latest --name $hostname --location $region --dns-name-label $hostname --resource-group GitHubActions-RG --cpu 4 --memory 8 --ports 8080 38888 --ip-address public --environment-variables RAVEN_ServerUrl="http://0.0.0.0:8080" RAVEN_ServerUrl_Tcp="tcp://0.0.0.0:38888" RAVEN_PublicServerUrl="http://$($hostname).$($region).azurecontainer.io:8080" RAVEN_PublicServerUrl_Tcp="tcp://$($hostname).$($region).azurecontainer.io:38888" RAVEN_Setup_Mode="None" RAVEN_License_Eula_Accepted="true" RAVEN_Security_UnsecuredAccessAllowed="PublicNetwork" | ConvertFrom-Json
+              
+              # echo will mess up the return value
+              Write-Debug "Tagging container image"
+              $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
+              $ignore = az tag create --resource-id $details.id --tags Package=RavenPersistence RunnerOS=$runnerOs $dateTag
+
+              return $details.ipAddress.fqdn
+          }
+
+          $prefix = "psw-ravendb-gateway-$(Get-Random)"
+
+          echo "::set-output name=prefix::$prefix"
+
+          $fqdnRavenDB = @(0, 1, 2, 3)
+
+          $NewRavenDBNodeDef = $function:NewRavenDBNode.ToString()
+
+          $fqdnRavenDB | ForEach-Object -Parallel {
+              $function:NewRavenDBNode = $using:NewRavenDBNodeDef
+              $region = $using:region;
+              $prefix = $using:prefix;
+              $detail = NewRavenDBNode $region $prefix $_ ${{ runner.os }}
+              $arr = $using:fqdnRavenDB;
+              $arr[$_] = $detail
+          }
+
+          $fqdnRavenDB | ForEach-Object -Parallel {
+              echo "::add-mask::$_"
+              $tcpClient = New-Object Net.Sockets.TcpClient
+              echo "Verifying connection $_"
+              do
               {
-                  $tcpClient.Connect($fqdn, 8080)
-              } catch 
-              {
-                  Start-Sleep -Seconds 2
-              }
-          } While($tcpClient.Connected -ne "True")
-          echo "Connection verified"
-          
+                  try
+                  {
+                      echo "Trying to connect to $_"
+                      $tcpClient.Connect($_, 8080)
+                      echo "Connection to $_ successful"
+                  } catch 
+                  {
+                      Start-Sleep -Seconds 2
+                  }
+              } While($tcpClient.Connected -ne "True")
+              $tcpClient.Close()
+              echo "Connection to $_ verified"
+          }
+
+          echo "Activating license on $($fqdnRavenDB[0])"
+          curl "http://$($fqdnRavenDB[0]):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
+
+          echo "Activating license on $($fqdnRavenDB[1])"
+          curl "http://$($fqdnRavenDB[1]):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
+
+          curl "http://$($fqdnRavenDB[1]):8080/admin/license/set-limit?nodeTag=A&newAssignedCores=1" -X POST -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB[2]):8080") 
+          curl "http://$($fqdnRavenDB[1]):8080/admin/cluster/node?url=$($encodedURL)&tag=B&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB[3]):8080")
+          curl "http://$($fqdnRavenDB[1]):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+
+          echo "RavenSingleNodeUrl=http://$($fqdnRavenDB[0]):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "CommaSeparatedRavenClusterUrls=http://$($fqdnRavenDB[1]):8080,http://$($fqdnRavenDB[2]):8080,http://$($fqdnRavenDB[3]):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+
       - name: Run tests
         uses: Particular/run-tests-action@v1.0.0
       - name: Teardown RavenDB
         if: ${{ always() }}
         uses: Azure/powershell@v1
         with:
-          inlineScript: Remove-AzContainerGroup -ResourceGroupName GitHubActions-RG -Name ${{ steps.setup-ravendb.outputs.hostname }}
+          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ steps.setup-ravendb.outputs.prefix }}*" } | Remove-AzContainerGroup
           azPSVersion: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
                   $region,
                   $prefix,
                   $instanceId,
-                  $runnerOs
+                  $runnerOs,
+                  $commit
               )
 
               $hostname = "$prefix-$instanceId"
@@ -93,7 +94,7 @@ jobs:
               # echo will mess up the return value
               Write-Debug "Tagging container image"
               $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
-              $ignore = az tag create --resource-id $details.id --tags Package=RavenPersistence RunnerOS=$runnerOs $dateTag
+              $ignore = az tag create --resource-id $details.id --tags Package=RavenGatewayPersistence RunnerOS=$runnerOs Commit=$commit $dateTag
 
               return $details.ipAddress.fqdn
           }
@@ -110,7 +111,7 @@ jobs:
               $function:NewRavenDBNode = $using:NewRavenDBNodeDef
               $region = $using:region;
               $prefix = $using:prefix;
-              $detail = NewRavenDBNode $region $prefix $_ ${{ runner.os }}
+              $detail = NewRavenDBNode $region $prefix $_ ${{ runner.os }} ${GITHUB_SHA}
               $arr = $using:fqdnRavenDB;
               $arr[$_] = $detail
           }
@@ -158,5 +159,5 @@ jobs:
         if: ${{ always() }}
         uses: Azure/powershell@v1
         with:
-          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ steps.setup-ravendb.outputs.prefix }}*" } | Remove-AzContainerGroup
+          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ steps.setup-ravendb.outputs.prefix }}*" } | Remove-AzContainerGroup | Out-Null
           azPSVersion: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,12 +130,9 @@ jobs:
           retention-days: 1
 
   build:
-    if:
-      (github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
-      github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: setup
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,8 @@ jobs:
           }
 
           @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
-              echo "::add-mask::$fqdnRavenDB[$_]"
+              $hashTable = $using:fqdnRavenDB;
+              echo "::add-mask::$hashTable[$_]"
               $tcpClient = New-Object Net.Sockets.TcpClient
               echo "Verifying connection $_"
               do
@@ -125,7 +126,7 @@ jobs:
                   try
                   {
                       echo "Trying to connect to $_"
-                      $tcpClient.Connect($fqdnRavenDB[$_], 8080)
+                      $tcpClient.Connect($hashTable[$_], 8080)
                       echo "Connection to $_ successful"
                   } catch 
                   {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,21 +103,21 @@ jobs:
 
           echo "::set-output name=prefix::$prefix"
 
-          $fqdnRavenDB = @(0, 1, 2, 3)
+          $fqdnRavenDB = @ { singlenode = ""; leader = ""; follower1 = ""; follower2 = "" } 
 
           $NewRavenDBNodeDef = $function:NewRavenDBNode.ToString()
 
-          $fqdnRavenDB | ForEach-Object -Parallel {
+          @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
               $function:NewRavenDBNode = $using:NewRavenDBNodeDef
               $region = $using:region;
               $prefix = $using:prefix;
               $detail = NewRavenDBNode $region $prefix $_ ${{ runner.os }} ${{ github.sha }}
-              $arr = $using:fqdnRavenDB;
-              $arr[$_] = $detail
+              $hashTable = $using:fqdnRavenDB;
+              $hashTable[$_] = $detail
           }
 
-          $fqdnRavenDB | ForEach-Object -Parallel {
-              echo "::add-mask::$_"
+          @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
+              echo "::add-mask::$fqdnRavenDB[$_]"
               $tcpClient = New-Object Net.Sockets.TcpClient
               echo "Verifying connection $_"
               do
@@ -125,7 +125,7 @@ jobs:
                   try
                   {
                       echo "Trying to connect to $_"
-                      $tcpClient.Connect($_, 8080)
+                      $tcpClient.Connect($fqdnRavenDB[$_], 8080)
                       echo "Connection to $_ successful"
                   } catch 
                   {
@@ -137,21 +137,21 @@ jobs:
           }
 
           # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
-          echo "Activating license on $($fqdnRavenDB[0])"
-          curl "http://$($fqdnRavenDB[0]):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
+          echo "Activating license on singlenode"
+          curl "http://$($fqdnRavenDB['singlenode']):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
 
           # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
-          echo "Activating license on $($fqdnRavenDB[1])"
-          curl "http://$($fqdnRavenDB[1]):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
+          echo "Activating license on leader"
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
 
-          curl "http://$($fqdnRavenDB[1]):8080/admin/license/set-limit?nodeTag=A&newAssignedCores=1" -X POST -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
-          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB[2]):8080") 
-          curl "http://$($fqdnRavenDB[1]):8080/admin/cluster/node?url=$($encodedURL)&tag=B&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
-          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB[3]):8080")
-          curl "http://$($fqdnRavenDB[1]):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/license/set-limit?nodeTag=A&newAssignedCores=1" -X POST -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower1']):8080") 
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=B&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower2']):8080")
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
 
-          echo "RavenSingleNodeUrl=http://$($fqdnRavenDB[0]):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          echo "CommaSeparatedRavenClusterUrls=http://$($fqdnRavenDB[1]):8080,http://$($fqdnRavenDB[2]):8080,http://$($fqdnRavenDB[3]):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "RavenSingleNodeUrl=http://$($fqdnRavenDB['singlenode']):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "CommaSeparatedRavenClusterUrls=http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
       - name: Run tests
         uses: Particular/run-tests-action@v1.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,11 @@ jobs:
               echo "Connection to $_ verified"
           }
 
+          # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
           echo "Activating license on $($fqdnRavenDB[0])"
           curl "http://$($fqdnRavenDB[0]):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
 
+          # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
           echo "Activating license on $($fqdnRavenDB[1])"
           curl "http://$($fqdnRavenDB[1]):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
           echo "::set-output name=prefix::$prefix"
 
-          $fqdnRavenDB = @ { singlenode = ""; leader = ""; follower1 = ""; follower2 = "" } 
+          $fqdnRavenDB = @{ singlenode = ""; leader = ""; follower1 = ""; follower2 = "" } 
 
           $NewRavenDBNodeDef = $function:NewRavenDBNode.ToString()
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           $hostInfo = curl -H Metadata:true "169.254.169.254/metadata/instance?api-version=2017-08-01" | ConvertFrom-Json
           $region = $hostInfo.compute.location
-          $license = '${{ secrets.RAVENDB_LICENSE_WINDOWS }}'
+          $license = '${{ secrets.RAVENDB_LICENSE }}'
 
           function NewRavenDBNode {
               param (

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           $hostname = "psw-ravendb-$(Get-Random)"
           echo "::set-output name=hostname::$hostname"
           echo "Creating RavenDB container $name (This can take awhile.)"
-          $details = az container create --image ravendb/ravendb:4.2-ubuntu-latest  --name $hostname --dns-name-label $hostname --resource-group GitHubActions-RG --cpu 1 --memory 3.5 --ports 8080 38888 --ip-address public -e RAVEN_ARGS='--ServerUrl=http://0.0.0.0:8080 --Setup.Mode=None --License.Eula.Accepted=true --Security.UnsecuredAccessAllowed=PublicNetwork' | ConvertFrom-Json
+          $details = az container create --image ravendb/ravendb:5.2-ubuntu-latest  --name $hostname --dns-name-label $hostname --resource-group GitHubActions-RG --cpu 1 --memory 3.5 --ports 8080 38888 --ip-address public -e RAVEN_ARGS='--ServerUrl=http://0.0.0.0:8080 --Setup.Mode=None --License.Eula.Accepted=true --Security.UnsecuredAccessAllowed=PublicNetwork' | ConvertFrom-Json
 
           $fqdn=$details.ipAddress.fqdn
           echo "::add-mask::$fqdn"
@@ -81,6 +81,21 @@ jobs:
           $ignore = az tag create --resource-id $details.id --tags Package=Gateway.RavenDB RunnerOS=${{ runner.os }} $dateTag
 
           echo "CommaSeparatedRavenClusterUrls=http://$($fqdn):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          
+          $tcpClient = New-Object Net.Sockets.TcpClient
+          echo "Verifying connection"
+          do
+          {
+              try
+              {
+                  $tcpClient.Connect($fqdn, 8080)
+              } catch 
+              {
+                  Start-Sleep -Seconds 2
+              }
+          } While($tcpClient.Connected -ne "True")
+          echo "Connection verified"
+          
       - name: Run Windows tests
         if: runner.os == 'Windows'
         run: dotnet test src --configuration Release --no-build --logger "GitHubActions;report-warnings=false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,125 @@ on:
 env:
   DOTNET_NOLOGO: true
 jobs:
+  setup:
+    if:
+      (github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') ||
+      github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    name: Setup RavenDB Nodes
+    runs-on: ubuntu-20.04
+    outputs:
+      prefix: ${{ steps.setup-ravendb.outputs.prefix }}
+    steps:
+      - name: Azure login
+        uses: azure/login@v1.4.1
+        with:
+          creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
+          enable-AzPSSession: true
+      - name: Setup RavenDB
+        id: setup-ravendb
+        shell: pwsh
+        run: |
+          $hostInfo = curl -H Metadata:true "169.254.169.254/metadata/instance?api-version=2017-08-01" | ConvertFrom-Json
+          $region = $hostInfo.compute.location
+          $license = '${{ secrets.RAVENDB_LICENSE }}'
+
+          function NewRavenDBNode {
+              param (
+                  $region,
+                  $prefix,
+                  $instanceId,
+                  $runnerOs,
+                  $commit
+              )
+
+              $hostname = "$prefix-$instanceId"
+
+              # echo will mess up the return value
+              Write-Debug "Creating RavenDB container $hostname in $region (This can take a while.)"
+
+              $details = az container create --image ravendb/ravendb:5.2-ubuntu-latest --name $hostname --location $region --dns-name-label $hostname --resource-group GitHubActions-RG --cpu 4 --memory 8 --ports 8080 38888 --ip-address public --environment-variables RAVEN_ServerUrl="http://0.0.0.0:8080" RAVEN_ServerUrl_Tcp="tcp://0.0.0.0:38888" RAVEN_PublicServerUrl="http://$($hostname).$($region).azurecontainer.io:8080" RAVEN_PublicServerUrl_Tcp="tcp://$($hostname).$($region).azurecontainer.io:38888" RAVEN_Setup_Mode="None" RAVEN_License_Eula_Accepted="true" RAVEN_Security_UnsecuredAccessAllowed="PublicNetwork" | ConvertFrom-Json
+              
+              # echo will mess up the return value
+              Write-Debug "Tagging container image"
+              $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
+              $ignore = az tag create --resource-id $details.id --tags Package=RavenGatewayPersistence RunnerOS=$runnerOs Commit=$commit $dateTag
+
+              return $details.ipAddress.fqdn
+          }
+
+          $prefix = "psw-ravendb-gateway-$(Get-Random)"
+
+          echo "::set-output name=prefix::$prefix"
+
+          $fqdnRavenDB = @{ singlenode = ""; leader = ""; follower1 = ""; follower2 = "" }
+
+          $NewRavenDBNodeDef = $function:NewRavenDBNode.ToString()
+
+          @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
+              $function:NewRavenDBNode = $using:NewRavenDBNodeDef
+              $region = $using:region;
+              $prefix = $using:prefix;
+              $detail = NewRavenDBNode $region $prefix $_ ${{ runner.os }} ${{ github.sha }}
+              $hashTable = $using:fqdnRavenDB;
+              $hashTable[$_] = $detail
+          }
+
+          @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
+              $hashTable = $using:fqdnRavenDB;
+              $tcpClient = New-Object Net.Sockets.TcpClient
+              echo "Verifying connection $_"
+              do
+              {
+                  try
+                  {
+                      echo "Trying to connect to $_"
+                      $tcpClient.Connect($hashTable[$_], 8080)
+                      echo "Connection to $_ successful"
+                  } catch 
+                  {
+                      Start-Sleep -Seconds 2
+                  }
+              } While($tcpClient.Connected -ne "True")
+              $tcpClient.Close()
+              echo "Connection to $_ verified"
+          }
+
+          # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
+          echo "Activating license on singlenode"
+          curl "http://$($fqdnRavenDB['singlenode']):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
+
+          # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
+          echo "Activating license on leader"
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
+
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/license/set-limit?nodeTag=A&newAssignedCores=1" -X POST -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower1']):8080") 
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=B&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower2']):8080")
+          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
+
+          $singlenodeurl = "http://$($fqdnRavenDB['singlenode']):8080"
+          echo "::set-output name=singlenodeurl::$singlenodeurl"
+          echo "::add-mask::$singlenodeurl"
+
+          $clusterurl = "http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080"
+          echo "::set-output name=clusterurl::$clusterurl"
+          echo "::add-mask::$clusterurl"
+      - name: Encrypt Urls
+        run: |
+          # Unfortunately masking breaks job outputs so we go the extra mile
+          echo ${{ steps.setup-ravendb.outputs.singlenodeurl }} | gpg --quiet --symmetric --cipher-algo AES256 --batch --yes --passphrase '${{ secrets.PASSPHRASE }}' --output singlenodeurl.txt.gpg
+          echo ${{ steps.setup-ravendb.outputs.clusterurl }} | gpg --quiet --symmetric --cipher-algo AES256 --batch --yes --passphrase '${{ secrets.PASSPHRASE }}' --output clusterurl.txt.gpg
+      - name: Upload Urls
+        uses: actions/upload-artifact@v2
+        with:
+          name: ravendburls
+          path: |
+            singlenodeurl.txt.gpg
+            clusterurl.txt.gpg
+          retention-days: 1
+
   build:
     if:
       (github.event_name == 'pull_request_target' && github.event.pull_request.user.login == 'dependabot[bot]') ||
@@ -59,103 +178,42 @@ jobs:
           name: NuGet packages
           path: nugets/
           retention-days: 7
+      - name: Download Urls
+        uses: actions/download-artifact@v2
+        with:
+          name: ravendburls
+      - name: Prepare for tests
+        id: prepare
+        shell: pwsh
+        run: |
+          # Unfortunately masking breaks job outputs so we go the extra mile
+          gpg --quiet --batch --yes --decrypt --passphrase='${{ secrets.PASSPHRASE }}' --output singlenodeurl.txt singlenodeurl.txt.gpg
+          gpg --quiet --batch --yes --decrypt --passphrase='${{ secrets.PASSPHRASE }}' --output clusterurl.txt clusterurl.txt.gpg
+          $singlenodeurl = cat singlenodeurl.txt
+          echo "::add-mask::$singlenodeurl"
+          echo "::set-output name=singlenodeurl::$singlenodeurl"
+          $clusterurl = cat clusterurl.txt
+          echo "::add-mask::$clusterurl"
+          echo "::set-output name=clusterurl::$clusterurl"
+      - name: Run tests
+        env:
+          RavenSingleNodeUrl: ${{ steps.prepare.outputs.singlenodeurl }}
+          CommaSeparatedRavenClusterUrls: ${{ steps.prepare.outputs.clusterurl }}
+        uses: Particular/run-tests-action@v1.0.0
+
+  cleanup:
+    runs-on: ubuntu-20.04
+    if: ${{ always() }}
+    needs: [setup, build]
+    steps:
       - name: Azure login
-        uses: azure/login@v1.3.0
+        uses: azure/login@v1.4.1
         with:
           creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
           enable-AzPSSession: true
-      - name: Setup RavenDB
-        id: setup-ravendb
-        shell: pwsh
-        run: |
-          $hostInfo = curl -H Metadata:true "169.254.169.254/metadata/instance?api-version=2017-08-01" | ConvertFrom-Json
-          $region = $hostInfo.compute.location
-          $license = '${{ secrets.RAVENDB_LICENSE }}'
-
-          function NewRavenDBNode {
-              param (
-                  $region,
-                  $prefix,
-                  $instanceId,
-                  $runnerOs,
-                  $commit
-              )
-
-              $hostname = "$prefix-$instanceId"
-
-              # echo will mess up the return value
-              Write-Debug "Creating RavenDB container $hostname in $region (This can take a while.)"
-
-              $details = az container create --image ravendb/ravendb:5.2-ubuntu-latest --name $hostname --location $region --dns-name-label $hostname --resource-group GitHubActions-RG --cpu 4 --memory 8 --ports 8080 38888 --ip-address public --environment-variables RAVEN_ServerUrl="http://0.0.0.0:8080" RAVEN_ServerUrl_Tcp="tcp://0.0.0.0:38888" RAVEN_PublicServerUrl="http://$($hostname).$($region).azurecontainer.io:8080" RAVEN_PublicServerUrl_Tcp="tcp://$($hostname).$($region).azurecontainer.io:38888" RAVEN_Setup_Mode="None" RAVEN_License_Eula_Accepted="true" RAVEN_Security_UnsecuredAccessAllowed="PublicNetwork" | ConvertFrom-Json
-              
-              # echo will mess up the return value
-              Write-Debug "Tagging container image"
-              $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
-              $ignore = az tag create --resource-id $details.id --tags Package=RavenGatewayPersistence RunnerOS=$runnerOs Commit=$commit $dateTag
-
-              return $details.ipAddress.fqdn
-          }
-
-          $prefix = "psw-ravendb-gateway-$(Get-Random)"
-
-          echo "::set-output name=prefix::$prefix"
-
-          $fqdnRavenDB = @{ singlenode = ""; leader = ""; follower1 = ""; follower2 = "" } 
-
-          $NewRavenDBNodeDef = $function:NewRavenDBNode.ToString()
-
-          @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
-              $function:NewRavenDBNode = $using:NewRavenDBNodeDef
-              $region = $using:region;
-              $prefix = $using:prefix;
-              $detail = NewRavenDBNode $region $prefix $_ ${{ runner.os }} ${{ github.sha }}
-              $hashTable = $using:fqdnRavenDB;
-              $hashTable[$_] = $detail
-          }
-
-          @($fqdnRavenDB.keys) | ForEach-Object -Parallel {
-              $hashTable = $using:fqdnRavenDB;
-              echo "::add-mask::$hashTable[$_]"
-              $tcpClient = New-Object Net.Sockets.TcpClient
-              echo "Verifying connection $_"
-              do
-              {
-                  try
-                  {
-                      echo "Trying to connect to $_"
-                      $tcpClient.Connect($hashTable[$_], 8080)
-                      echo "Connection to $_ successful"
-                  } catch 
-                  {
-                      Start-Sleep -Seconds 2
-                  }
-              } While($tcpClient.Connected -ne "True")
-              $tcpClient.Close()
-              echo "Connection to $_ verified"
-          }
-
-          # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
-          echo "Activating license on singlenode"
-          curl "http://$($fqdnRavenDB['singlenode']):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
-
-          # Once you set the license on a node, it assumes the node to be a cluster, so only set the license on the leader
-          echo "Activating license on leader"
-          curl "http://$($fqdnRavenDB['leader']):8080/admin/license/activate" -H 'Content-Type: application/json; charset=UTF-8' -d "$($license)"
-
-          curl "http://$($fqdnRavenDB['leader']):8080/admin/license/set-limit?nodeTag=A&newAssignedCores=1" -X POST -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
-          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower1']):8080") 
-          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=B&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
-          $encodedURL = [System.Web.HttpUtility]::UrlEncode("http://$($fqdnRavenDB['follower2']):8080")
-          curl "http://$($fqdnRavenDB['leader']):8080/admin/cluster/node?url=$($encodedURL)&tag=C&watcher=true&assignedCores=1" -X PUT -H 'Content-Type: application/json; charset=utf-8' -H 'Content-Length: 0'
-
-          echo "RavenSingleNodeUrl=http://$($fqdnRavenDB['singlenode']):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-          echo "CommaSeparatedRavenClusterUrls=http://$($fqdnRavenDB['leader']):8080,http://$($fqdnRavenDB['follower1']):8080,http://$($fqdnRavenDB['follower2']):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-
-      - name: Run tests
-        uses: Particular/run-tests-action@v1.0.0
       - name: Teardown RavenDB
         if: ${{ always() }}
         uses: Azure/powershell@v1
         with:
-          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ steps.setup-ravendb.outputs.prefix }}*" } | Remove-AzContainerGroup | Out-Null
+          inlineScript: Get-AzContainerGroup -ResourceGroupName GitHubActions-RG | Where-Object { $_.Name -like "${{ needs.setup.outputs.prefix }}*" } | Remove-AzContainerGroup | Out-Null
           azPSVersion: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
           $ignore = az tag create --resource-id $details.id --tags Package=Gateway.RavenDB RunnerOS=${{ runner.os }} $dateTag
 
-          echo "CommaSeparatedRavenClusterUrls=http://$($fqdn):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+          echo "RavenSingleNodeUrl=http://$($fqdn):8080" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
           
           $tcpClient = New-Object Net.Sockets.TcpClient
           echo "Verifying connection"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
               $function:NewRavenDBNode = $using:NewRavenDBNodeDef
               $region = $using:region;
               $prefix = $using:prefix;
-              $detail = NewRavenDBNode $region $prefix $_ ${{ runner.os }} ${GITHUB_SHA}
+              $detail = NewRavenDBNode $region $prefix $_ ${{ runner.os }} ${{ github.sha }}
               $arr = $using:fqdnRavenDB;
               $arr[$_] = $detail
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,6 @@ jobs:
           $hostInfo = curl -H Metadata:true "169.254.169.254/metadata/instance?api-version=2017-08-01" | ConvertFrom-Json
           $region = $hostInfo.compute.location
           $license = '${{ secrets.RAVENDB_LICENSE_WINDOWS }}'
-          if ($PSVersionTable.Platform -eq 'Unix') {
-              $license = '${{ secrets.RAVENDB_LICENSE_LINUX }}'
-          }
 
           function NewRavenDBNode {
               param (

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ If you are interested in contributing, please follow the instructions [here.](ht
 
 ## Running the tests
 
-Running the tests requires RavenDB 4.2 and an environment variable named `CommaSeparatedRavenClusterUrls` containing the connection URLs, separated by commas if testing a cluster. The tests can be run with a RavenDB server hosted on a Docker container.
+Running the tests requires RavenDB 5.2 and two environment variables. One named `CommaSeparatedRavenClusterUrls` containing the URLs, separated by commas, to connect to a RavenDB cluster to run cluster-wide transaction tests. The second one named `RavenSingleNodeUrl` containing the URL of a single node RavenDB instance to run non-cluster-wide tests. The tests can be run with RavenDB servers hosted on a Docker container.

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -32,7 +32,10 @@
                 }
 
                 return documentStore;
-            });
+            })
+            {
+                DisableClusterWideTransactions = true
+            };
 
             var gatewaySettings = configuration.Gateway(ravenGatewayDeduplicationConfiguration);
             configuration.GetSettings().Set(gatewaySettings);

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -89,15 +89,15 @@
 
         static DocumentStore GetInitializedDocumentStore(string defaultDatabase)
         {
-            var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls");
-            if (urls == null)
+            var url = Environment.GetEnvironmentVariable("RavenSingleNodeUrl");
+            if (url == null)
             {
-                throw new Exception("RavenDB cluster URLs must be specified in an environment variable named CommaSeparatedRavenClusterUrls.");
+                throw new Exception("RavenDB URL must be specified in an environment variable named RavenSingleNodeUrl.");
             }
 
             var documentStore = new DocumentStore
             {
-                Urls = urls.Split(','),
+                Urls = new[] { url },
                 Database = defaultDatabase
             };
 

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -32,10 +32,7 @@
                 }
 
                 return documentStore;
-            })
-            {
-                DisableClusterWideTransactions = true
-            };
+            });
 
             var gatewaySettings = configuration.Gateway(ravenGatewayDeduplicationConfiguration);
             configuration.GetSettings().Set(gatewaySettings);

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="4.0.0-alpha.244" />
-    <PackageReference Include="RavenDB.Client" Version="5.2.3" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="4.0.0-alpha.244" />
-    <PackageReference Include="RavenDB.Client" Version="4.2.111" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/.editorconfig
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/.editorconfig
@@ -1,0 +1,10 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none
+
+# may be enabled in future
+dotnet_diagnostic.PS0018.severity = suggestion  # A task-returning method should have a CancellationToken parameter unless it has a parameter implementing ICancellableContext
+
+# Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
+dotnet_diagnostic.NSB0002.severity = suggestion

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -1,0 +1,109 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.Configuration.AdvancedExtensibility;
+    using Raven.Client.Documents;
+    using Raven.Client.ServerWide;
+    using Raven.Client.ServerWide.Operations;
+    using System;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using System.Threading;
+
+    public partial class GatewayTestSuiteConstraints
+    {
+        public Task<GatewayDeduplicationConfiguration> ConfigureDeduplicationStorage(string endpointName, EndpointConfiguration configuration, RunSettings settings)
+        {
+            var ravenGatewayDeduplicationConfiguration = new RavenGatewayDeduplicationConfiguration((builder, _) =>
+            {
+                var databaseName = Guid.NewGuid().ToString();
+                var documentStore = GetInitializedDocumentStore(databaseName);
+
+                documentStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName)));
+
+                try
+                {
+                    semaphoreSlim.Wait();
+                    databases.Add(databaseName);
+                }
+                finally
+                {
+                    semaphoreSlim.Release();
+                }
+
+                return documentStore;
+            });
+
+            var gatewaySettings = configuration.Gateway(ravenGatewayDeduplicationConfiguration);
+            configuration.GetSettings().Set(gatewaySettings);
+
+            return Task.FromResult<GatewayDeduplicationConfiguration>(ravenGatewayDeduplicationConfiguration);
+        }
+
+        public async Task Cleanup()
+        {
+            await semaphoreSlim.WaitAsync();
+            try
+            {
+                foreach (var databaseName in databases)
+                {
+                    // Periodically the delete will throw an exception because Raven has the database locked
+                    // To solve this we have a retry loop with a delay
+                    var triesLeft = 3;
+
+                    while (triesLeft-- > 0)
+                    {
+                        try
+                        {
+                            // We are using a new store because the global one is disposed of before cleanup
+                            using (var storeForDeletion = GetInitializedDocumentStore(databaseName))
+                            {
+                                storeForDeletion.Maintenance.Server.Send(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
+                                break;
+                            }
+                        }
+                        catch
+                        {
+                            if (triesLeft == 0)
+                            {
+                                throw;
+                            }
+
+                            await Task.Delay(250);
+                        }
+                    }
+
+                    Console.WriteLine("Deleted '{0}' database", databaseName);
+                }
+
+                databases.Clear();
+            }
+            finally
+            {
+                semaphoreSlim.Release();
+            }
+        }
+
+        static DocumentStore GetInitializedDocumentStore(string defaultDatabase)
+        {
+            var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls");
+            if (urls == null)
+            {
+                throw new Exception("RavenDB cluster URLs must be specified in an environment variable named CommaSeparatedRavenClusterUrls.");
+            }
+
+            var documentStore = new DocumentStore
+            {
+                Urls = urls.Split(','),
+                Database = defaultDatabase
+            };
+
+            documentStore.Initialize();
+
+            return documentStore;
+        }
+
+        static SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
+        List<string> databases = new List<string>();
+    }
+}

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -32,7 +32,10 @@
                 }
 
                 return documentStore;
-            });
+            })
+            {
+                EnableClusterWideTransactions = true
+            };
 
             var gatewaySettings = configuration.Gateway(ravenGatewayDeduplicationConfiguration);
             configuration.GetSettings().Set(gatewaySettings);

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="4.0.0-alpha.244" />
-    <PackageReference Include="RavenDB.Client" Version="5.2.3" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Gateway.RavenDB\NServiceBus.Gateway.RavenDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="4.0.0-alpha.244" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/SetupFixture.cs
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/SetupFixture.cs
@@ -1,0 +1,19 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    using NUnit.Framework;
+
+    [SetUpFixture]
+    public class SetupFixture
+    {
+        [OneTimeSetUp]
+        public void Setup()
+        {
+#if NET472
+            // Weird bug about deserialization of objects across AppDomains
+            // Otherwise it wants test classes to be marked as serializable in net461
+            // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/mitigation-deserialization-of-objects-across-app-domains
+            System.Configuration.ConfigurationManager.GetSection("dummy");
+#endif
+        }
+    }
+}

--- a/src/NServiceBus.Gateway.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBusGatewayRavenDB.approved.txt
+++ b/src/NServiceBus.Gateway.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBusGatewayRavenDB.approved.txt
@@ -4,6 +4,7 @@ namespace NServiceBus
     {
         public RavenGatewayDeduplicationConfiguration(System.Func<System.IServiceProvider, NServiceBus.Settings.IReadOnlySettings, Raven.Client.Documents.IDocumentStore> documentStoreFactory) { }
         public System.TimeSpan DeduplicationDataTimeToLive { get; set; }
+        public bool DisableClusterWideTransactions { get; set; }
         public long FrequencyToRunDeduplicationDataCleanup { get; set; }
         public override NServiceBus.Gateway.IGatewayDeduplicationStorage CreateStorage(System.IServiceProvider builder) { }
         public override void Setup(NServiceBus.Settings.IReadOnlySettings settings) { }

--- a/src/NServiceBus.Gateway.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBusGatewayRavenDB.approved.txt
+++ b/src/NServiceBus.Gateway.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBusGatewayRavenDB.approved.txt
@@ -4,7 +4,7 @@ namespace NServiceBus
     {
         public RavenGatewayDeduplicationConfiguration(System.Func<System.IServiceProvider, NServiceBus.Settings.IReadOnlySettings, Raven.Client.Documents.IDocumentStore> documentStoreFactory) { }
         public System.TimeSpan DeduplicationDataTimeToLive { get; set; }
-        public bool DisableClusterWideTransactions { get; set; }
+        public bool EnableClusterWideTransactions { get; set; }
         public long FrequencyToRunDeduplicationDataCleanup { get; set; }
         public override NServiceBus.Gateway.IGatewayDeduplicationStorage CreateStorage(System.IServiceProvider builder) { }
         public override void Setup(NServiceBus.Settings.IReadOnlySettings settings) { }

--- a/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NServiceBus.Gateway" Version="4.0.0-alpha.244" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="RavenDB.Client" Version="5.2.3" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NServiceBus.Gateway" Version="4.0.0-alpha.244" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="RavenDB.Client" Version="4.2.111" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.sln
+++ b/src/NServiceBus.Gateway.RavenDB.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Gateway.RavenDB", "NServiceBus.Gateway.RavenDB\NServiceBus.Gateway.RavenDB.csproj", "{7B24118B-16F2-4B66-9CBC-887030428B04}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Gateway.RavenDB.AcceptanceTests", "NServiceBus.Gateway.RavenDB.AcceptanceTests\NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj", "{7ADB5C0D-1C66-4270-90A6-10E90AD5781E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Gateway.RavenDB.Tests", "NServiceBus.Gateway.RavenDB.Tests\NServiceBus.Gateway.RavenDB.Tests.csproj", "{975E7C1E-C0C4-40AD-AEF8-B588B63EA1C7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Gateway.RavenDB.Tests", "NServiceBus.Gateway.RavenDB.Tests\NServiceBus.Gateway.RavenDB.Tests.csproj", "{975E7C1E-C0C4-40AD-AEF8-B588B63EA1C7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests", "NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests\NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj", "{8D78316A-2180-40F0-BF4D-A8CDDC2B2FC2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{975E7C1E-C0C4-40AD-AEF8-B588B63EA1C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{975E7C1E-C0C4-40AD-AEF8-B588B63EA1C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{975E7C1E-C0C4-40AD-AEF8-B588B63EA1C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D78316A-2180-40F0-BF4D-A8CDDC2B2FC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D78316A-2180-40F0-BF4D-A8CDDC2B2FC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D78316A-2180-40F0-BF4D-A8CDDC2B2FC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D78316A-2180-40F0-BF4D-A8CDDC2B2FC2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
+++ b/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1897, 9.0.0)" />
     <PackageReference Include="NServiceBus.Gateway" Version="[4.0.0-alpha.244, 5.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
-    <PackageReference Include="RavenDB.Client" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="RavenDB.Client" Version="[5.2.0, 6.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
+++ b/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.1897, 9.0.0)" />
     <PackageReference Include="NServiceBus.Gateway" Version="[4.0.0-alpha.244, 5.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
-    <PackageReference Include="RavenDB.Client" Version="[5.2.0, 6.0.0)" />
+    <PackageReference Include="RavenDB.Client" Version="[5.2.1, 6.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
+++ b/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
@@ -36,14 +36,14 @@
         {
             var documentStore = documentStoreFactory(builder, settings);
 
-            if (DisableClusterWideTransactions)
+            if (!EnableClusterWideTransactions)
             {
                 // Currently do not support running without cluister-wide TX and clusters with more than one node.
                 EnsureClusterConfiguration(documentStore);
             }
             EnableExpirationFeature(documentStore, FrequencyToRunDeduplicationDataCleanup);
 
-            return new RavenGatewayDeduplicationStorage(documentStore, DeduplicationDataTimeToLive, !DisableClusterWideTransactions);
+            return new RavenGatewayDeduplicationStorage(documentStore, DeduplicationDataTimeToLive, EnableClusterWideTransactions);
         }
 
         static void EnableExpirationFeature(IDocumentStore documentStore, long frequencyToRunDeduplicationDataCleanup)
@@ -80,10 +80,10 @@
         public long FrequencyToRunDeduplicationDataCleanup { get; set; } = 600;
 
         /// <summary>
-        /// Disables Cluster-wide transactions support to improve performance when runing against a single node.
-        /// Cluster-wide transactions cannot be disabled when runnign agains a cluster with more than one node.
+        /// Enables Cluster-wide transactions support. Cluster-wide transactions must 
+        /// be enabled when running against a cluster with more than one node.
         /// </summary>
-        public bool DisableClusterWideTransactions { get; set; }
+        public bool EnableClusterWideTransactions { get; set; }
 
         IReadOnlySettings settings;
         readonly Func<IServiceProvider, IReadOnlySettings, IDocumentStore> documentStoreFactory;

--- a/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
+++ b/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
@@ -36,11 +36,7 @@
         {
             var documentStore = documentStoreFactory(builder, settings);
 
-            if (!EnableClusterWideTransactions)
-            {
-                // Currently do not support running without cluister-wide TX and clusters with more than one node.
-                EnsureClusterConfiguration(documentStore);
-            }
+            EnsureClusterConfiguration(documentStore);
             EnableExpirationFeature(documentStore, FrequencyToRunDeduplicationDataCleanup);
 
             return new RavenGatewayDeduplicationStorage(documentStore, DeduplicationDataTimeToLive, EnableClusterWideTransactions);
@@ -55,16 +51,16 @@
             }));
         }
 
-        static void EnsureClusterConfiguration(IDocumentStore store)
+        void EnsureClusterConfiguration(IDocumentStore store)
         {
             using (var s = store.OpenSession())
             {
                 var getTopologyCmd = new GetDatabaseTopologyCommand();
                 s.Advanced.RequestExecutor.Execute(getTopologyCmd, s.Advanced.Context);
 
-                if (getTopologyCmd.Result.Nodes.Count != 1)
+                if (getTopologyCmd.Result.Nodes.Count > 1 && !EnableClusterWideTransactions)
                 {
-                    throw new InvalidOperationException("RavenDB Persistence does not support RavenDB clusters with more than one Leader/Member node. Only clusters with a single Leader and (optionally) Watcher nodes are supported.");
+                    throw new InvalidOperationException("The RavenDB cluster contains multiple nodes. To safely operate in multi-node environments, enable cluster-wide transactions.");
                 }
             }
         }
@@ -80,7 +76,7 @@
         public long FrequencyToRunDeduplicationDataCleanup { get; set; } = 600;
 
         /// <summary>
-        /// Enables Cluster-wide transactions support. Cluster-wide transactions must 
+        /// Enables Cluster-wide transactions support. Cluster-wide transactions must
         /// be enabled when running against a cluster with more than one node.
         /// </summary>
         public bool EnableClusterWideTransactions { get; set; }

--- a/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationStorage.cs
@@ -26,6 +26,10 @@
             };
 
             var session = documentStore.OpenAsyncSession(options);
+
+            // Optimistic concurrency is incompatible with cluster-wide transactions
+            session.Advanced.UseOptimisticConcurrency = !useClusterWideTransactions;
+
             var isDuplicate = await session.LoadAsync<GatewayMessage>(MessageIdHelper.EscapeMessageId(messageId), cancellationToken).ConfigureAwait(false) != null;
 
             return new RavenDeduplicationSession(session, isDuplicate, messageId, deduplicationDataTimeToLive);

--- a/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationStorage.cs
@@ -5,20 +5,27 @@
     using System.Threading.Tasks;
     using Extensibility;
     using Raven.Client.Documents;
+    using Raven.Client.Documents.Session;
 
     class RavenGatewayDeduplicationStorage : IGatewayDeduplicationStorage
     {
-        public RavenGatewayDeduplicationStorage(IDocumentStore documentStore, TimeSpan deduplicationDataTimeToLive)
+        public RavenGatewayDeduplicationStorage(IDocumentStore documentStore, TimeSpan deduplicationDataTimeToLive, bool useClusterWideTransactions)
         {
             this.documentStore = documentStore;
             this.deduplicationDataTimeToLive = deduplicationDataTimeToLive;
+            this.useClusterWideTransactions = useClusterWideTransactions;
         }
 
         public bool SupportsDistributedTransactions => false;
 
         public async Task<IDeduplicationSession> CheckForDuplicate(string messageId, ContextBag context, CancellationToken cancellationToken = default)
         {
-            var session = documentStore.OpenAsyncSession();
+            var options = new SessionOptions()
+            {
+                TransactionMode = useClusterWideTransactions ? TransactionMode.ClusterWide : TransactionMode.SingleNode
+            };
+
+            var session = documentStore.OpenAsyncSession(options);
             var isDuplicate = await session.LoadAsync<GatewayMessage>(MessageIdHelper.EscapeMessageId(messageId), cancellationToken).ConfigureAwait(false) != null;
 
             return new RavenDeduplicationSession(session, isDuplicate, messageId, deduplicationDataTimeToLive);
@@ -26,5 +33,6 @@
 
         readonly IDocumentStore documentStore;
         readonly TimeSpan deduplicationDataTimeToLive;
+        readonly bool useClusterWideTransactions;
     }
 }


### PR DESCRIPTION
## PoA

- [x] retarget to `master` once https://github.com/Particular/NServiceBus.Gateway.RavenDB/pull/176 is merged
- [x] Add ATT permutation to test against a proper cluster
- [x] Throw when cluster-wide tx are not enabled and the topology contains multiple nodes