### PR TITLE
Make sure the RavenDB server is 5.2 or higher

### DIFF
--- a/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
+++ b/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
@@ -75,11 +75,11 @@
 
             if (fullVersion.Major < requiredVersion.Major)
             {
-                throw new Exception("The RavenDB persistence requires RavenDB server 5.2 or higher");
+                throw new Exception($"We detected that the server is running on version {serverVersion.FullVersion}. RavenDB persistence requires RavenDB server 5.2 or higher");
             }
             if (fullVersion.Major == requiredVersion.Major && fullVersion.Minor < requiredVersion.Minor)
             {
-                throw new Exception("The RavenDB persistence requires RavenDB server 5.2 or higher");
+                throw new Exception($"We detected that the server is running on version {serverVersion.FullVersion}. RavenDB persistence requires RavenDB server 5.2 or higher");
             }
         }
 

--- a/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
+++ b/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
@@ -73,11 +73,8 @@
             var serverVersion = documentStore.Maintenance.Server.Send(new GetBuildNumberOperation());
             var fullVersion = new Version(serverVersion.FullVersion);
 
-            if (fullVersion.Major < requiredVersion.Major)
-            {
-                throw new Exception($"We detected that the server is running on version {serverVersion.FullVersion}. RavenDB persistence requires RavenDB server 5.2 or higher");
-            }
-            if (fullVersion.Major == requiredVersion.Major && fullVersion.Minor < requiredVersion.Minor)
+            if (fullVersion.Major < requiredVersion.Major ||
+                (fullVersion.Major == requiredVersion.Major && fullVersion.Minor < requiredVersion.Minor))
             {
                 throw new Exception($"We detected that the server is running on version {serverVersion.FullVersion}. RavenDB persistence requires RavenDB server 5.2 or higher");
             }


### PR DESCRIPTION
To safely support cluster-wide transactions, we require the RavenDB server to be 5.2 or higher.