### PR TITLE
Add support for RavenDB 5.x cluster-wide transactions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         id: setup-ravendb
         shell: pwsh
         run: |
-          $hostInfo = curl -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance?api-version=2021-02-01" | ConvertFrom-Json
+          $hostInfo = curl -H Metadata:true "169.254.169.254/metadata/instance?api-version=2017-08-01" | ConvertFrom-Json
           $region = $hostInfo.compute.location
           $license = '${{ secrets.RAVENDB_LICENSE }}'
 
@@ -47,7 +47,7 @@ jobs:
               # echo will mess up the return value
               Write-Debug "Creating RavenDB container $hostname in $region (This can take a while.)"
 
-              $details = az container create --image ravendb/ravendb:4.2-ubuntu-latest --name $hostname --location $region --dns-name-label $hostname --resource-group GitHubActions-RG --cpu 4 --memory 8 --ports 8080 38888 --ip-address public --environment-variables RAVEN_ServerUrl="http://0.0.0.0:8080" RAVEN_ServerUrl_Tcp="tcp://0.0.0.0:38888" RAVEN_PublicServerUrl="http://$($hostname).$($region).azurecontainer.io:8080" RAVEN_PublicServerUrl_Tcp="tcp://$($hostname).$($region).azurecontainer.io:38888" RAVEN_Setup_Mode="None" RAVEN_License_Eula_Accepted="true" RAVEN_ARGS='--Security.UnsecuredAccessAllowed=PublicNetwork' | ConvertFrom-Json
+              $details = az container create --image ravendb/ravendb:5.2-ubuntu-latest --name $hostname --location $region --dns-name-label $hostname --resource-group GitHubActions-RG --cpu 4 --memory 8 --ports 8080 38888 --ip-address public --environment-variables RAVEN_ServerUrl="http://0.0.0.0:8080" RAVEN_ServerUrl_Tcp="tcp://0.0.0.0:38888" RAVEN_PublicServerUrl="http://$($hostname).$($region).azurecontainer.io:8080" RAVEN_PublicServerUrl_Tcp="tcp://$($hostname).$($region).azurecontainer.io:38888" RAVEN_Setup_Mode="None" RAVEN_License_Eula_Accepted="true" RAVEN_Security_UnsecuredAccessAllowed="PublicNetwork" | ConvertFrom-Json
               
               # echo will mess up the return value
               Write-Debug "Tagging container image"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ If you are interested in contributing, please follow the instructions [here.](ht
 ## Running the tests
 
 Running the tests requires RavenDB 5.2 and two environment variables. One named `CommaSeparatedRavenClusterUrls` containing the URLs, separated by commas, to connect to a RavenDB cluster to run cluster-wide transaction tests. The second one named `RavenSingleNodeUrl` containing the URL of a single node RavenDB instance to run non-cluster-wide tests. The tests can be run with RavenDB servers hosted on a Docker container.
+
+### Spinning up the necessary infrastructure
+
+This assumes docker and docker-compose are properly setup. It works currently on Windows with Docker Desktop but not on docker hosted in WSL2 only.
+
+1. [Acquire a developer license](https://ravendb.net/license/request/dev)
+1. Convert the multi-line license JSON to a single line JSON and set the `LICENSE` variable. Alternatively the license can be set using [an `.env` file](https://docs.docker.com/compose/environment-variables/).
+1. Inside the root directory of the repository issue the following command: `docker-compose up -d`.
+
+The single node server is reachable under [`http://localhost:8080`](http://localhost:8080). The cluster leader is reachable under [`http://localhost:8081`](http://localhost:8081).

--- a/README.md
+++ b/README.md
@@ -8,14 +8,4 @@ If you are interested in contributing, please follow the instructions [here.](ht
 
 ## Running the tests
 
-Running the tests requires RavenDB 4.2 and an environment variable named `CommaSeparatedRavenClusterUrls` containing the connection URLs, separated by commas if testing a cluster. The tests can be run with a RavenDB server hosted on a Docker container.
-
-### Spinning up the necessary infrastructure
-
-This assumes docker and docker-compose are properly setup. It works currently on Windows with Docker Desktop but not on docker hosted in WSL2 only.
-
-1. [Acquire a developer license](https://ravendb.net/license/request/dev)
-1. Convert the multi-line license JSON to a single line JSON and set the `LICENSE` variable. Alternatively the license can be set using [an `.env` file](https://docs.docker.com/compose/environment-variables/).
-1. Inside the root directory of the repository issue the following command: `docker-compose up -d`.
-
-The single node server is reachable under [`http://localhost:8080`](http://localhost:8080). The cluster leader is reachable under [`http://localhost:8081`](http://localhost:8081).
+Running the tests requires RavenDB 5.2 and two environment variables. One named `CommaSeparatedRavenClusterUrls` containing the URLs, separated by commas, to connect to a RavenDB cluster to run cluster-wide transaction tests. The second one named `RavenSingleNodeUrl` containing the URL of a single node RavenDB instance to run non-cluster-wide tests. The tests can be run with RavenDB servers hosted on a Docker container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   singlenode:
     container_name: singlenode
-    image: ravendb/ravendb:4.2-ubuntu-latest
+    image: ravendb/ravendb:5.2-ubuntu-latest
     ports:
       - 8080:8080
       - 38888:38888
@@ -34,7 +34,7 @@ services:
         - singlenode_network
   leader:
     container_name: leader
-    image: ravendb/ravendb:4.2-ubuntu-latest
+    image: ravendb/ravendb:5.2-ubuntu-latest
     ports:
       - 8081:8080
       - 38889:38888
@@ -53,7 +53,7 @@ services:
             ipv4_address: 172.29.1.1
   follower1:
     container_name: follower1
-    image: ravendb/ravendb:4.2-ubuntu-latest
+    image: ravendb/ravendb:5.2-ubuntu-latest
     depends_on:
       - leader
     ports:
@@ -74,7 +74,7 @@ services:
             ipv4_address: 172.29.1.2
   follower2:
     container_name: follower2
-    image: ravendb/ravendb:4.2-ubuntu-latest
+    image: ravendb/ravendb:5.2-ubuntu-latest
     depends_on:
       - leader
     ports:

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -61,11 +61,15 @@ namespace NServiceBus.Gateway.AcceptanceTests
 
         static DocumentStore GetInitializedDocumentStore(string defaultDatabase)
         {
-            var urls = Environment.GetEnvironmentVariable("RavenSingleNodeUrl") ?? "http://localhost:8080";
+            var url = Environment.GetEnvironmentVariable("RavenSingleNodeUrl");
+            if (url == null)
+            {
+                throw new Exception("RavenDB URL must be specified in an environment variable named RavenSingleNodeUrl.");
+            }
 
             var documentStore = new DocumentStore
             {
-                Urls = urls.Split(','),
+                Urls = new[] { url },
                 Database = defaultDatabase
             };
 

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Gateway.AcceptanceTests
     {
         public Task ConfigureDeduplicationStorage(string endpointName, EndpointConfiguration configuration, RunSettings settings)
         {
-            var ravenGatewayDeduplicationConfiguration = new RavenGatewayDeduplicationConfiguration((builder, _)=> 
+            var ravenGatewayDeduplicationConfiguration = new RavenGatewayDeduplicationConfiguration((builder, _) => 
             {
                 databaseName = Guid.NewGuid().ToString();
                 var documentStore = GetInitializedDocumentStore(databaseName);
@@ -41,7 +41,7 @@ namespace NServiceBus.Gateway.AcceptanceTests
                     // We are using a new store because the global one is disposed of before cleanup
                     using (var storeForDeletion = GetInitializedDocumentStore(databaseName))
                     {
-                        storeForDeletion.Maintenance.Server.Send(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
+                        await storeForDeletion.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
                         break;
                     }
                 }

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -61,11 +61,7 @@ namespace NServiceBus.Gateway.AcceptanceTests
 
         static DocumentStore GetInitializedDocumentStore(string defaultDatabase)
         {
-            var url = Environment.GetEnvironmentVariable("RavenSingleNodeUrl");
-            if (url == null)
-            {
-                throw new Exception("RavenDB URL must be specified in an environment variable named RavenSingleNodeUrl.");
-            }
+            var url = Environment.GetEnvironmentVariable("RavenSingleNodeUrl") ?? "http://localhost:8080";
 
             var documentStore = new DocumentStore
             {

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.2.3" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="3.1.0" />
-    <PackageReference Include="RavenDB.Client" Version="4.2.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.ClusterCheck.AcceptanceTests/GatewayEndpoint.cs
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterCheck.AcceptanceTests/GatewayEndpoint.cs
@@ -70,7 +70,7 @@
                     // We are using a new store because the global one is disposed of before cleanup
                     using (var storeForDeletion = GetInitializedDocumentStore(databaseName))
                     {
-                        storeForDeletion.Maintenance.Server.Send(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
+                        await storeForDeletion.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
                         break;
                     }
                 }

--- a/src/NServiceBus.Gateway.RavenDB.ClusterCheck.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterCheck.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterCheck.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterCheck.AcceptanceTests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.2.3" />
-    <PackageReference Include="RavenDB.Client" Version="4.2.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -64,11 +64,7 @@ namespace NServiceBus.Gateway.AcceptanceTests
 
         static DocumentStore GetInitializedDocumentStore(string defaultDatabase)
         {
-            var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls");
-            if (urls == null)
-            {
-                throw new Exception("RavenDB cluster URLs must be specified in an environment variable named CommaSeparatedRavenClusterUrls.");
-            }
+            var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls") ?? "http://localhost:8081,http://localhost:8082,http://localhost:8083";
 
             var documentStore = new DocumentStore
             {

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -1,0 +1,86 @@
+﻿using NServiceBus.AcceptanceTesting.Support;
+using NServiceBus.Configuration.AdvancedExtensibility;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using System;
+using System.Threading.Tasks;
+
+namespace NServiceBus.Gateway.AcceptanceTests
+{
+    public partial class GatewayTestSuiteConstraints
+    {
+        public Task ConfigureDeduplicationStorage(string endpointName, EndpointConfiguration configuration, RunSettings settings)
+        {
+            var ravenGatewayDeduplicationConfiguration = new RavenGatewayDeduplicationConfiguration((builder, _)=> 
+            {
+                databaseName = Guid.NewGuid().ToString();
+                var documentStore = GetInitializedDocumentStore(databaseName);
+
+                documentStore.Maintenance.Server.Send(new CreateDatabaseOperation(new DatabaseRecord(databaseName)));
+
+                return documentStore;
+            })
+            {
+                EnableClusterWideTransactions = true
+            };
+
+            var gatewaySettings = configuration.Gateway(ravenGatewayDeduplicationConfiguration);
+            configuration.GetSettings().Set(gatewaySettings);
+
+            return Task.CompletedTask;
+        }
+
+        public async Task Cleanup()
+        {
+            // Periodically the delete will throw an exception because Raven has the database locked
+            // To solve this we have a retry loop with a delay
+            var triesLeft = 3;
+
+            while (triesLeft-- > 0)
+            {
+                try
+                {
+                    // We are using a new store because the global one is disposed of before cleanup
+                    using (var storeForDeletion = GetInitializedDocumentStore(databaseName))
+                    {
+                        storeForDeletion.Maintenance.Server.Send(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
+                        break;
+                    }
+                }
+                catch
+                {
+                    if (triesLeft == 0)
+                    {
+                        throw;
+                    }
+
+                    await Task.Delay(250);
+                }
+            }
+
+            Console.WriteLine("Deleted '{0}' database", databaseName);
+        }
+
+        static DocumentStore GetInitializedDocumentStore(string defaultDatabase)
+        {
+            var urls = Environment.GetEnvironmentVariable("CommaSeparatedRavenClusterUrls");
+            if (urls == null)
+            {
+                throw new Exception("RavenDB cluster URLs must be specified in an environment variable named CommaSeparatedRavenClusterUrls.");
+            }
+
+            var documentStore = new DocumentStore
+            {
+                Urls = urls.Split(','),
+                Database = defaultDatabase
+            };
+
+            documentStore.Initialize();
+
+            return documentStore;
+        }
+
+        string databaseName;
+    }
+}

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/GatewayTestSuiteConstraints.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Gateway.AcceptanceTests
     {
         public Task ConfigureDeduplicationStorage(string endpointName, EndpointConfiguration configuration, RunSettings settings)
         {
-            var ravenGatewayDeduplicationConfiguration = new RavenGatewayDeduplicationConfiguration((builder, _)=> 
+            var ravenGatewayDeduplicationConfiguration = new RavenGatewayDeduplicationConfiguration((builder, _) => 
             {
                 databaseName = Guid.NewGuid().ToString();
                 var documentStore = GetInitializedDocumentStore(databaseName);
@@ -44,7 +44,7 @@ namespace NServiceBus.Gateway.AcceptanceTests
                     // We are using a new store because the global one is disposed of before cleanup
                     using (var storeForDeletion = GetInitializedDocumentStore(databaseName))
                     {
-                        storeForDeletion.Maintenance.Server.Send(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
+                        await storeForDeletion.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(storeForDeletion.Database, hardDelete: true));
                         break;
                     }
                 }

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Gateway.RavenDB\NServiceBus.Gateway.RavenDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.2.3" />
+    <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="3.1.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/SetupFixture.cs
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/SetupFixture.cs
@@ -1,0 +1,19 @@
+﻿namespace NServiceBus.Gateway.AcceptanceTests
+{
+    using NUnit.Framework;
+
+    [SetUpFixture]
+    public class SetupFixture
+    {
+        [OneTimeSetUp]
+        public void Setup()
+        {
+#if NET461
+            // Weird bug about deserialization of objects across AppDomains
+            // Otherwise it wants test classes to be marked as serializable in net461
+            // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/mitigation-deserialization-of-objects-across-app-domains
+            System.Configuration.ConfigurationManager.GetSection("dummy");
+#endif
+        }
+    }
+}

--- a/src/NServiceBus.Gateway.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBusGatewayRavenDB.approved.txt
+++ b/src/NServiceBus.Gateway.RavenDB.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBusGatewayRavenDB.approved.txt
@@ -4,6 +4,7 @@ namespace NServiceBus
     {
         public RavenGatewayDeduplicationConfiguration(System.Func<NServiceBus.ObjectBuilder.IBuilder, NServiceBus.Settings.ReadOnlySettings, Raven.Client.Documents.IDocumentStore> documentStoreFactory) { }
         public System.TimeSpan DeduplicationDataTimeToLive { get; set; }
+        public bool EnableClusterWideTransactions { get; set; }
         public long FrequencyToRunDeduplicationDataCleanup { get; set; }
         public override NServiceBus.Gateway.IGatewayDeduplicationStorage CreateStorage(NServiceBus.ObjectBuilder.IBuilder builder) { }
         public override void Setup(NServiceBus.Settings.ReadOnlySettings settings) { }

--- a/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
@@ -14,9 +14,9 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.2.3" />
     <PackageReference Include="NServiceBus.Gateway" Version="3.1.0" />
-    <PackageReference Include="Particular.Approvals" Version="0.2.0" />
+    <PackageReference Include="Particular.Approvals" Version="0.3.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
-    <PackageReference Include="RavenDB.Client" Version="4.2.0" />
+    <PackageReference Include="RavenDB.Client" Version="5.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.sln
+++ b/src/NServiceBus.Gateway.RavenDB.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Gateway.RavenDB
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Gateway.RavenDB.ClusterCheck.AcceptanceTests", "NServiceBus.Gateway.RavenDB.ClusterCheck.AcceptanceTests\NServiceBus.Gateway.RavenDB.ClusterCheck.AcceptanceTests.csproj", "{C5089CD2-FCA3-493C-936D-310F707AC8F3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests", "NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests\NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj", "{5CDF980F-D1F3-49D5-911D-0538368AA041}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{C5089CD2-FCA3-493C-936D-310F707AC8F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C5089CD2-FCA3-493C-936D-310F707AC8F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C5089CD2-FCA3-493C-936D-310F707AC8F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CDF980F-D1F3-49D5-911D-0538368AA041}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CDF980F-D1F3-49D5-911D-0538368AA041}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CDF980F-D1F3-49D5-911D-0538368AA041}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CDF980F-D1F3-49D5-911D-0538368AA041}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
+++ b/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NServiceBus.Gateway" Version="[3.1.0, 4.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="1.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
-    <PackageReference Include="RavenDB.Client" Version="[4.2.0, 5.0.0)" />
+    <PackageReference Include="RavenDB.Client" Version="[5.2.1, 6.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
+++ b/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationConfiguration.cs
@@ -63,7 +63,7 @@
 
                 if (getTopologyCmd.Result.Nodes.Count > 1 && !EnableClusterWideTransactions)
                 {
-                    throw new InvalidOperationException("The RavenDB cluster contains multiple nodes. To safely operate in multi-node environments, enable cluster-wide transactions.");
+                    throw new Exception($"The configured database is replicated across multiple nodes, in order to continue, use {nameof(EnableClusterWideTransactions)} on the gateway configuration.");
                 }
             }
         }

--- a/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationStorage.cs
+++ b/src/NServiceBus.Gateway.RavenDB/RavenGatewayDeduplicationStorage.cs
@@ -2,22 +2,33 @@
 {
     using Extensibility;
     using Raven.Client.Documents;
+    using Raven.Client.Documents.Session;
     using System;
     using System.Threading.Tasks;
 
     class RavenGatewayDeduplicationStorage : IGatewayDeduplicationStorage
     {
-        public RavenGatewayDeduplicationStorage(IDocumentStore documentStore, TimeSpan deduplicationDataTimeToLive)
+        public RavenGatewayDeduplicationStorage(IDocumentStore documentStore, TimeSpan deduplicationDataTimeToLive, bool useClusterWideTransactions)
         {
             this.documentStore = documentStore;
             this.deduplicationDataTimeToLive = deduplicationDataTimeToLive;
+            this.useClusterWideTransactions = useClusterWideTransactions;
         }
 
         public bool SupportsDistributedTransactions => false;
 
         public async Task<IDeduplicationSession> CheckForDuplicate(string messageId, ContextBag context)
         {
-            var session = documentStore.OpenAsyncSession();
+            var options = new SessionOptions()
+            {
+                TransactionMode = useClusterWideTransactions ? TransactionMode.ClusterWide : TransactionMode.SingleNode
+            };
+
+            var session = documentStore.OpenAsyncSession(options);
+
+            // Optimistic concurrency is incompatible with cluster-wide transactions
+            session.Advanced.UseOptimisticConcurrency = !useClusterWideTransactions;
+
             var isDuplicate = await session.LoadAsync<GatewayMessage>(MessageIdHelper.EscapeMessageId(messageId)).ConfigureAwait(false) != null;
 
             return new RavenDeduplicationSession(session, isDuplicate, messageId, deduplicationDataTimeToLive);
@@ -25,5 +36,6 @@
 
         readonly IDocumentStore documentStore;
         readonly TimeSpan deduplicationDataTimeToLive;
+        readonly bool useClusterWideTransactions;
     }
 }


### PR DESCRIPTION
Introduce support for RavenDB 5 cluster-wide transactions. Cluster-wide transactions allow the safe use of RavenDB clusters where the database is replicated on more than one node. Requires RavenDB 5.2.1 or greater. The persisted will check the server version and throw if a mismatch is detected.

## PoA

- [x] Create branch `release-2.0`
- [x] Create milestone `2.0.0`
- [x] PR description