### PR TITLE
Upgrade RavenDB.Client to v6.2.8 in Gateway

### DIFF
--- a/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
+++ b/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="10.0.0-alpha.3" />
     <PackageReference Include="NServiceBus.Gateway" Version="6.0.0-alpha.2" />
-    <PackageReference Include="RavenDB.Client" Version="5.4.209" />
+  <PackageReference Include="RavenDB.Client" Version="6.2.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
+++ b/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="10.0.0-alpha.3" />
     <PackageReference Include="NServiceBus.Gateway" Version="6.0.0-alpha.2" />
-  <PackageReference Include="RavenDB.Client" Version="6.2.8" />
+    <PackageReference Include="RavenDB.Client" Version="6.2.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- https://github.com/Particular/NServiceBus.RavenDB/issues/1341

This change updates the RavenDB.Client NuGet package from version 5.4.209 to 6.2.8.