### PR TITLE
Downgrade to .NET 8 for the RavenDB 6.2 support release

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.200",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
-    "allowPrerelease": true,
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <MinVerMinimumMajorMinor>5.0</MinVerMinimumMajorMinor>
-    <MinVerAutoIncrement>minor</MinVerAutoIncrement>
+    <MinVerAutoIncrement>patch</MinVerAutoIncrement>
   </PropertyGroup>
 
 </Project>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <MinVerMinimumMajorMinor>6.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
-
+  
 </Project>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -4,5 +4,5 @@
     <MinVerMinimumMajorMinor>5.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>
-  
+
 </Project>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <MinVerMinimumMajorMinor>6.0</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>5.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
   </PropertyGroup>
   

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="10.0.0-alpha.3" />
-    <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="6.0.0-alpha.2" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.3" />
+    <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="5.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.AcceptanceTests/NServiceBus.Gateway.RavenDB.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.3" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.7" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="5.1.0" />
   </ItemGroup>
 

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="10.0.0-alpha.3" />
-    <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="6.0.0-alpha.2" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.3" />
+    <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="5.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests/NServiceBus.Gateway.RavenDB.ClusterWideTx.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.3" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="9.2.7" />
     <PackageReference Include="NServiceBus.Gateway.AcceptanceTests.Sources" Version="5.1.0" />
   </ItemGroup>
 

--- a/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
+++ b/src/NServiceBus.Gateway.RavenDB.Tests/NServiceBus.Gateway.RavenDB.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
+++ b/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="10.0.0-alpha.3" />
-    <PackageReference Include="NServiceBus.Gateway" Version="6.0.0-alpha.2" />
+    <PackageReference Include="NServiceBus" Version="9.2.3" />
+    <PackageReference Include="NServiceBus.Gateway" Version="5.1.0" />
     <PackageReference Include="RavenDB.Client" Version="6.2.9" />
   </ItemGroup>
 

--- a/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
+++ b/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="9.2.3" />
+    <PackageReference Include="NServiceBus" Version="9.2.7" />
     <PackageReference Include="NServiceBus.Gateway" Version="5.1.0" />
     <PackageReference Include="RavenDB.Client" Version="6.2.9" />
   </ItemGroup>


### PR DESCRIPTION
This PR downgrades some of the changes done on `master` for the `release-5.0` branch to restore the state that is necessary to be compatible with NServiceBus v9. Those steps are necessary because we have decided to branch into a release branch from `master` instead of branching off from `release-4.0` and backporting the changes necessary. 