### PR TITLE
Use version range for RavenDB.Client package reference

### DIFF
--- a/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
+++ b/src/NServiceBus.Gateway.RavenDB/NServiceBus.Gateway.RavenDB.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="10.0.0-alpha.4" />
     <PackageReference Include="NServiceBus.Gateway" Version="6.0.0-alpha.2" />
-    <PackageReference Include="RavenDB.Client" Version="6.2.9" />
+    <PackageReference Include="RavenDB.Client" Version="[6.2.9,8.0.0)" AutomaticVersionRange="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changed the RavenDB.Client in NServiceBus.RavenDB from a fixed version (6.2.9) to a version range ([6.2.9,8.0.0)), allowing updates up to but not including 8.0.0. This provides more flexibility for compatible updates.